### PR TITLE
docs: GitHub 上でスペースの量がずれたので修正

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ refactor: 関数の分割
 
 ```
 └─ Assets
-     ├─ MyGame        <- 外部ライブラリ以外の自作物はこのディレクトリ以下に置く
+     ├─ MyGame       <- 外部ライブラリ以外の自作物はこのディレクトリ以下に置く
      │   ├─ Prefabs  <- プレハブを置く
      │   │   ├─ ExamplePrefab.prefab
      │   │   ├─ ExamplePrefab.prefab.meta


### PR DESCRIPTION
## 変更内容
- GitHub 上でスペースの量がずれたので修正

## 解決する Issue
- close #18 

## 関連する Issue
<!-- その他関連する Issue があれば、ここに記述 -->
- #16 

<!--
 ✅ 右サイドから Reviewers を指定する
 ✅ 右サイドから Labels を指定する
-->
