### PR TITLE
ライフとPiのUIを画面の大きさに合わせて調整

### DIFF
--- a/Assets/MyGame/Scenes/SampleStageScene.unity
+++ b/Assets/MyGame/Scenes/SampleStageScene.unity
@@ -907,6 +907,22 @@ PrefabInstance:
       propertyPath: m_Name
       value: LifePiUI
       objectReference: {fileID: 0}
+    - target: {fileID: 7636031785294497063, guid: aacecc53f65db4eb3a587577df6c4283, type: 3}
+      propertyPath: m_UiScaleMode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7636031785294497063, guid: aacecc53f65db4eb3a587577df6c4283, type: 3}
+      propertyPath: m_MatchWidthOrHeight
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7636031785294497063, guid: aacecc53f65db4eb3a587577df6c4283, type: 3}
+      propertyPath: m_ReferenceResolution.x
+      value: 1000
+      objectReference: {fileID: 0}
+    - target: {fileID: 7636031785294497063, guid: aacecc53f65db4eb3a587577df6c4283, type: 3}
+      propertyPath: m_ReferenceResolution.y
+      value: 700
+      objectReference: {fileID: 0}
     - target: {fileID: 7636031785483036952, guid: aacecc53f65db4eb3a587577df6c4283, type: 3}
       propertyPath: m_Sprite
       value: 


### PR DESCRIPTION
## 変更内容
- ライフとPiのUIを画面の大きさに合わせて調整

## 解決する Issue
- close #99 

## 関連する Issue
<!-- その他関連する Issue があれば、ここに記述 -->
- #0

<!--
 ✅ 右サイドから Reviewers を指定する
 ✅ 右サイドから Labels を指定する
-->
