### PR TITLE
外部アセットの保存場所統一に伴い不要になった記述を削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,3 @@ crashlytics-build.properties
 # AssetStore から import したアセットを Git 管理下に置かない
 /[Aa]ssets/*
 !/[Aa]ssets/MyGame/
-/[Aa]ssets/MyGame/Library/*


### PR DESCRIPTION
外部ライブラリの保存場所を Assets 直下とするため

## 変更内容
- `Assets/MyGame/Library/.gitkeep` を削除
- .gitignore から `Assets/MyGame/Library/*` を除外する記述を削除

## 解決する Issue
- close #129 

<!--
 ✅ 右サイドから Reviewers を指定する
 ✅ 右サイドから Labels を指定する
-->
